### PR TITLE
Look for .csv in source dir even if exe is symlinked

### DIFF
--- a/searchsploit
+++ b/searchsploit
@@ -9,9 +9,15 @@ TAGS=
 SCASE='-i'
 VERBOSE=0
 
-# if files.csv is in the searchsploit path, use that
-if [ -f "$( dirname $0 )/files.csv" ]; then
-    csvpath="$( dirname $0 )/files.csv"
+# if files.csv is in the searchsploit source path, use that
+scriptsrc=$0
+while [ -h $scriptsrc ]; do
+  scriptsrc=$(readlink $scriptsrc)
+  [[ $scriptsrc != /* ]] && scriptsrc="$( cd -P $( dirname $scriptsrc ) && pwd )/$scriptsrc"
+done
+progdir="$( cd -P "$( dirname "$scriptsrc" )" && pwd )"
+if [ -f "$progdir/files.csv" ]; then
+    csvpath="$progdir/files.csv"
 fi
 
 # usage info


### PR DESCRIPTION
...Because it doesn't work if the script happens to be symlinked into say /usr/local/bin or whatever. Unfortunately, to be remain somewhat portable while allowing symlink chains, can't do this in a one-liner, meh. ;)
