### PR TITLE
Update to "gitpath" to reference new directory name

### DIFF
--- a/searchsploit
+++ b/searchsploit
@@ -10,7 +10,7 @@
 
 
 ## OS settings
-gitpath="/usr/share/exploitdb"
+gitpath="/usr/share/exploit-database"
 csvpath="${gitpath}/files.csv"
 
 ## Program settings


### PR DESCRIPTION
Small update to fix searchsploit.  The original "gitpath" pointed to "exploitdb/", which is no longer the correct directory name.