### PR TITLE
Use dir of searchsploit to find files.csv

### DIFF
--- a/searchsploit
+++ b/searchsploit
@@ -11,7 +11,7 @@
 
 
 ## OS settings
-gitpath="/usr/share/exploitdb"
+gitpath=$(dirname "$(readlink "$0")")
 csvpath="${gitpath}/files.csv"
 
 ## Program settings


### PR DESCRIPTION
Can't we just default it to the directory containing the ... well, the git checkout, like the variable name hints at? :)