### PR TITLE
Add -p parameter to get full exploit paths and copy to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Example:
    -e, --exact     Perform an EXACT match on exploit title (Default is AND) [Implies "-t"].
    -h, --help      Show this help screen.
    -o, --overflow  Exploit title's are allowed to overflow their columns.
+   -p, --path      Show the full path to an exploit (Copies path to clipboard if possible).
    -t, --title     Search just the exploit title (Default is title AND the file's path).
    -u, --update    Update exploit database from git.
    -w, --www       Show URLs to Exploit-DB.com rather than local path.

--- a/searchsploit
+++ b/searchsploit
@@ -190,8 +190,11 @@ done
 ## Print the full path. If pbcopy/xclip is available then copy to the clipboard
 if [[ "${GETPATH}" -eq '1' ]]; then
 
-  tag="$( echo ${TAGS} | tr '[:upper:]' '[:lower:]' )"
-  location=${gitpath}/platforms/${tag//.\//}
+  tag="$(echo ${TAGS} | tr '[:upper:]' '[:lower:]')"
+  edbid=$(echo "${tag}" | tr -dc '0-9')
+  edbpath=$(awk -F ',' '{print $2}' ${csvpath} | grep -E "/${edbid}(\..*)?$")
+  location="${gitpath}/${edbpath}"
+
   echo "The exploit should be at: ${location}"
 
   # Are any copy programs available?

--- a/searchsploit
+++ b/searchsploit
@@ -25,6 +25,7 @@ COLOUR=1
 EDBID=0
 EXACT=0
 FILEPATH=1
+GETPATH=0
 OVERFLOW=0
 WEBLINK=0
 SCASE=0
@@ -60,6 +61,7 @@ function usage()
   echo "   -e, --exact     Perform an EXACT match on exploit title (Default is AND) [Implies \"-t\"]."
   echo "   -h, --help      Show this help screen."
   echo "   -o, --overflow  Exploit title's are allowed to overflow their columns."
+  echo "   -p, --path      Show the full path to an exploit (Copies path to clipboard if possible)."
   echo "   -t, --title     Search just the exploit title (Default is title AND the file's path)."
   echo "   -u, --update    Update exploit database from git."
   echo "   -w, --www       Show URLs to Exploit-DB.com rather than local path."
@@ -143,6 +145,8 @@ for param in "$@"; do
     usage >&2
   elif [[ "${param}" == "--overflow" ]]; then
     OVERFLOW=1
+  elif [[ "${param}" == "--path" ]]; then
+    GETPATH=1
   elif [[ "${param}" == "--title" ]]; then
     FILEPATH=0
   elif [[ "${param}" == "--update" ]]; then
@@ -165,7 +169,7 @@ done
 
 
 ## Parse short arguments
-while getopts "cehotuw" arg "${ARGS}"; do
+while getopts "cehoptuw" arg "${ARGS}"; do
   if [[ "${arg}" = "?" ]]; then
     usage >&2;
   fi
@@ -174,12 +178,36 @@ while getopts "cehotuw" arg "${ARGS}"; do
     e) EXACT=1;;
     h) usage >&2;;
     o) OVERFLOW=1;;
+    p) GETPATH=1;;
     t) FILEPATH=0;;
     u) update;;
     w) WEBLINK=1;;
   esac
   shift $(( OPTIND - 1 ))
 done
+
+
+## Print the full path. If pbcopy/xclip is available then copy to the clipboard
+if [[ "${GETPATH}" -eq '1' ]]; then
+
+  tag="$( echo ${TAGS} | tr '[:upper:]' '[:lower:]' )"
+  location=${gitpath}/platforms/${tag//.\//}
+  echo "The exploit should be at: ${location}"
+
+  # Are any copy programs available?
+  if hash xclip 2>/dev/null || hash pbcopy 2>/dev/null; then
+
+    if hash xclip 2>/dev/null; then
+      echo -ne "${location}" | xclip -selection clipboard
+    else
+      echo -ne "${location}" | pbcopy
+    fi
+
+    echo "Location has been copied to the clipboard."
+  fi
+
+  exit 0
+fi
 
 
 ## If we are doing an exact match, do not check folder path.


### PR DESCRIPTION
This PR allows for exploit paths to be printed in full based on the `Path` output from a search. Sample usage can be seen below.

```text
# search for an exploit
~ » searchsploit Sendpage Local Privilege Escalation
Linux Kernel - Sendpage Local Privilege Escalation  | ./linux/local/19933.rb

# copy and paste the path and re-run with the `-p` param
~ » searchsploit -p ./linux/local/19933.rb
The exploit should be at: /usr/share/exploitdb/platforms/linux/local/19933.rb
Location has been copied to the clipboard.
```