### PR TITLE
[UPD] improve git clone performances

### DIFF
--- a/searchsploit
+++ b/searchsploit
@@ -96,7 +96,7 @@ function update()
   if [[ "$( git rev-parse --is-inside-work-tree )" != "true" ]]; then
     if [[ "$( ls )" = "" ]]; then
       # If directory is empty, just clone
-      git clone "${gitremote}" .
+      git clone --depth=1 "${gitremote}" .
     else
       # If not empty, init and add remote
       git init >/dev/null


### PR DESCRIPTION
dear maintainers,

i reviewed the code of this script and i discovered that git clone works by cloning the current state of the repository and also all the history. i think that someone using searchsploit -u will not use the history, but only the current state.

so i propose you to use the option "--depth=1", which allows the clone of only the current state of the db.

if you think this is a bad idea for any reason, feel free to drop this request (if so, could you please let me know why? just because i am curious :D ).

thanks a lot for providing exploit-db, i really appreciate the effort and the project itself!

happy hacking!

Lo