### PR TITLE
Gets the physical script path in case of link

### DIFF
--- a/searchsploit
+++ b/searchsploit
@@ -12,7 +12,7 @@
 
 
 ## OS settings (get the path of where the script is stored + database file)
-gitpath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+gitpath="$( cd "$( dirname "$(realpath ${BASH_SOURCE[0]})" )" && pwd)"
 csvpath="${gitpath}/files.csv"
 
 


### PR DESCRIPTION
In case the searchexploit is executed with the path as a symbolic link the previous version of the script would look for the files.csv on the link folder. This change makes it look for it on the binary folder