### PR TITLE
Dynamically set the gitpath variable to the path where the shell script is located

### DIFF
--- a/searchsploit
+++ b/searchsploit
@@ -12,7 +12,7 @@
 
 
 ## OS settings (get the path of where the script is stored + database file)
-gitpath="/opt/exploit-database"
+gitpath="$(dirname $(readlink -f $0))"
 csvpath="${gitpath}/files.csv"
 
 


### PR DESCRIPTION
After cloning the repository and executing `searchsploit whatever`, you'll get the following error message:

    $ ./searchsploit whatever
    [!] Could not find:  /opt/exploit-database/files.csv

This is because the path of the `files.csv` file is set absolute:

    $ grep -E "(git|csv)path=" searchsploit 
    gitpath="/opt/exploit-database"
    csvpath="${gitpath}/files.csv"

This pull request does set the `gitpath` variable dynamically to the directory where the shell script is located.

EDIT: Just to mention: It does also follow every symlink, so `ln -s /path/to/searchsploit /usr/local/bin` will still work.