### PR TITLE
Fixed mistake in impacket imports

### DIFF
--- a/platforms/windows/remote/7132.py
+++ b/platforms/windows/remote/7132.py
@@ -15,8 +15,8 @@ from threading import Thread    #Thread is imported incase you would like to mod
 try:
     from impacket import smb
     from impacket import uuid
-    from impacket.dcerpc import dcerpc
-    from impacket.dcerpc import transport
+    from impacket import dcerpc
+    from impacket.dcerpc.v5 import transport
 except ImportError, _:
     print 'Install the following library to make this script work'
     print 'Impacket : http://oss.coresecurity.com/projects/impacket.html'


### PR DESCRIPTION
Two of the four imports from impacket had mistakes. You cannot load dcerpc from impacket.dcerpc. Also, the import of transport needs an additional step in the path.