### PR TITLE
Added missing library inclusion

### DIFF
--- a/platforms/unix/remote/22469.c
+++ b/platforms/unix/remote/22469.c
@@ -1,10 +1,8 @@
-source: http://www.securityfocus.com/bid/7294/info
- 
-A buffer overflow vulnerability has been reported for Samba. The problem occurs when copying user-supplied data into a static buffer. By passing excessive data to an affected Samba server, it may be possible for an anonymous user to corrupt sensitive locations in memory.
- 
-Successful exploitation of this issue could allow an attacker to execute arbitrary commands, with the privileges of the Samba process.
- 
-It should be noted that this vulnerability affects Samba 2.2.8 and earlier. Samba-TNG 0.3.1 and earlier are also affected. 
+/* source: http://www.securityfocus.com/bid/7294/info
+ A buffer overflow vulnerability has been reported for Samba. The problem occurs when copying user-supplied data into a static buffer. By passing excessive data to an affected Samba server, it may be possible for an anonymous user to corrupt sensitive locations in memory.
+ Successful exploitation of this issue could allow an attacker to execute arbitrary commands, with the privileges of the Samba process.
+ It should be noted that this vulnerability affects Samba 2.2.8 and earlier. Samba-TNG 0.3.1 and earlier are also affected. 
+*/
 
 /*  0x333hate => samba 2.2.x remote root exploit
  *
@@ -17,6 +15,7 @@ It should be noted that this vulnerability affects Samba 2.2.8 and earlier. Samb
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <sys/socket.h>
 #include <sys/types.h>


### PR DESCRIPTION
stdlib.h is required to make the function marco "fatal" work. Without stdlib.h, compiling with gcc fails.