### PR TITLE
Fix comparison in 9844.py

### DIFF
--- a/platforms/linux/local/9844.py
+++ b/platforms/linux/local/9844.py
@@ -16,7 +16,7 @@ while (i == 0):
         while (x == 0):
                 time.sleep(random.random()) #random int 0.0-1.0
                 pid = str(os.system("ps -efl | grep 'sleep 1' | grep -v grep | { read PID REST ; echo $PID; }"))
-                if (pid == 0): #need an active pid, race condition applies
+                if (pid == "0"): #need an active pid, race condition applies
                         print "[+] Didnt grab PID, got: " + pid + " -- Retrying..."
                         break
                 else:


### PR DESCRIPTION
`pid` will always be a string, so comparing it to 0 instead of "0" will always be false.