### PR TITLE
Fetch files.csv from same directory as searchsploit resides in

### DIFF
--- a/searchsploit
+++ b/searchsploit
@@ -13,7 +13,7 @@
 
 
 ## OS settings (get the path of where the script is stored + database file)
-gitpath="/opt/exploit-database"
+gitpath="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
 csvpath="${gitpath}/files.csv"
 
 


### PR DESCRIPTION
this fixes problems for people who checks out exploit-database manually and don't want to move stuff around e.g. mac users.