### PR TITLE
Made gitpath relative to location of searchsploit script.

### DIFF
--- a/searchsploit
+++ b/searchsploit
@@ -13,7 +13,7 @@
 
 
 ## OS settings (get the path of where the script is stored + database file)
-gitpath="/opt/exploit-database"
+gitpath="$(dirname $0)"
 csvpath="${gitpath}/files.csv"
 
 


### PR DESCRIPTION
**Problem Statement:**
* The current searchsploit only operates natively from /opt/.
* This is inconvenient for users who operate from $HOME/git or from an encrypted thumbdrive.

**Solution:**
This pull request makes the gitpath parameter relative to the searchsploit script so that once the user has cloned the repository, searchsploit can be executed without further configuration.