### PR TITLE
Fixing scanning mode.

### DIFF
--- a/exploits/php/remote/29316.py
+++ b/exploits/php/remote/29316.py
@@ -294,12 +294,12 @@ def wr1te_fil3(args):
 
 
 def run_threads(args, h0sts, m0de, vu1nz, rsa, rsb):
-    num_h0sts = len(h0sts)
-    num = 0
     try:
         if args.r:
             sc4n_r4ng3(args, m0de, rsa, rsb)
         else:
+            num_h0sts = len(h0sts)
+            num = 0
             for h0st in h0sts:
                 num += 1
                 if args.v:


### PR DESCRIPTION
When running with `-r`, `run_threads` is called with `None` as the second parameter. This causes `num_h0sts = len(h0sts)`  to raise a `TypeError: object of type 'NoneType' has no len()` error though. I just moved that calculation down inside the else so it will only run if `-r` wasn't specified.